### PR TITLE
add compatibility shim

### DIFF
--- a/semidbm/__init__.py
+++ b/semidbm/__init__.py
@@ -1,0 +1,2 @@
+# Compatibility layer
+from semidbm2 import *


### PR DESCRIPTION
Renaming the installed package name to `semidbm2` broke the main use case of the package: other third-party packages (pykakasi) that do `import semidbm` can't pick up this fixed version of the package if it's no longer called `semidbm` at runtime. Provide a compatibility alias so that internally we can install directly from this repo and have `pykakasi` work.